### PR TITLE
Fix all warnings in the Godot editor

### DIFF
--- a/break_eternity.gd
+++ b/break_eternity.gd
@@ -12,19 +12,19 @@
 
 class_name Decimal
 
-var sign : int = 0
-var layer : int = 0
-var mag : float = 0.00
+var sign: int = 0
+var layer: int = 0
+var mag: float = 0.00
 
-var m : float = 0.00
-var e : int = 0
+var m: float = 0.00
+var e: int = 0
 
 #Constants
 const ZERO = 0
 const ONE = 1
 const NEG_ONE = -1
 
-const E = 2.7182818284590452353602874713527 #No Godot internal variable for Euler's Number so this will have to do
+const E = 2.7182818284590452353602874713527 # No Godot internal variable for Euler's Number so this will have to do
 
 const MAX_SIGNIFICANT_DIGITS = 17
 const EXP_LIMIT = 9e15
@@ -43,7 +43,7 @@ const critical_tetr_values = [[
 	# Base 2 (using http://myweb.astate.edu/wpaulsen/tetcalc/tetcalc.html )
 	1, 1.0891180521811202527, 1.1789767925673958433, 1.2701455431742086633, 1.3632090180450091941, 1.4587818160364217007, 1.5575237916251418333, 1.6601571006859253673, 1.7674858188369780435, 1.8804192098842727359, 2], [
 	# Base E (using http://myweb.astate.edu/wpaulsen/tetcalc/tetcalc.html )
-	1, 1.1121114330934078681, 1.2310389249316089299, 1.3583836963111376089, 1.4960519303993531879, 1.6463542337511945810, 1.8121385357018724464, 1.9969713246183068478, 2.2053895545527544330, 2.4432574483385252544, E #1.0
+	1, 1.1121114330934078681, 1.2310389249316089299, 1.3583836963111376089, 1.4960519303993531879, 1.6463542337511945810, 1.8121385357018724464, 1.9969713246183068478, 2.2053895545527544330, 2.4432574483385252544, E # 1.0
 	], [
 	# Base 3
 	1, 1.1187738849693603, 1.2464963939368214, 1.38527004705667, 1.5376664685821402, 1.7068895236551784, 1.897001227148399, 2.1132403089001035, 2.362480153784171, 2.6539010333870774, 3], [
@@ -65,7 +65,7 @@ var critical_slog_values = [[
 	# Base 2
 	-1, -0.9194161097107025, -0.8335625019330468, -0.7425599821143978, -0.6466611521029437, -0.5462617907227869, -0.4419033816638769, -0.3342645487554494, -0.224140440909962, -0.11241087890006762, 0], [
 	# Base E
-	-1, -0.90603157029014, -0.80786507256596, -0.7064666939634, -0.60294836853664, -0.49849837513117, -0.39430303318768, -0.29147201034755, -0.19097820800866, -0.09361896280296, 0 #1.0
+	-1, -0.90603157029014, -0.80786507256596, -0.7064666939634, -0.60294836853664, -0.49849837513117, -0.39430303318768, -0.29147201034755, -0.19097820800866, -0.09361896280296, 0 # 1.0
 	], [
 	# Base 3
 	-1, -0.9021579584316141, -0.8005762598234203, -0.6964780623319391, -0.5911906810998454, -0.486050182576545, -0.3823089430815083, -0.28106046722897615, -0.1831906535795894, -0.08935809204418144, 0], [
@@ -84,7 +84,7 @@ var critical_slog_values = [[
 	# Base 10
 	-1, -0.8641642839543857, -0.732534623168535, -0.6083127477059322, -0.4934049257184696, -0.3885773075899922, -0.29376029055315767, -0.2083678561173622, -0.13155653399373268, -0.062401588652553186, 0]]
 
-func _init(_sign : int, _layer : int, _mag : float):
+func _init(_sign: int, _layer: int, _mag: float):
 	sign = _sign
 	layer = _layer
 	mag = _mag
@@ -109,10 +109,10 @@ func f_gamma(n):
 	var scal1 = 1
 	while n < 10:
 		scal1 = scal1 * n
-		++n
-	
+		n += 1
+
 	n -= 1
-	var l = 0.9189385332046727; #0.5*log(2*PI)
+	var l = 0.9189385332046727; # 0.5*log(2*PI)
 	l = l + (n + 0.5) * log(n)
 	l = l - n
 	var n2 = n * n
@@ -140,7 +140,7 @@ func decimal_places(value, places):
 	var rounded = round(value * pow(10, len - numDigits)) * pow(10, numDigits - len)
 	return snapped(rounded, max(len - numDigits, 0))
 
-func f_lambertw(z, tol : float = 1e-10):
+func f_lambertw(z, tol: float = 1e-10):
 	var w
 	var wn
 	if not is_finite(z):
@@ -153,7 +153,7 @@ func f_lambertw(z, tol : float = 1e-10):
 		w = 0
 	else:
 		w = log(z) - log(log(z))
-	
+
 	for i in range(0, 100):
 		wn = (z * exp(-w) + w * w) / (w + 1)
 		if abs(wn - w) < tol * abs(wn):
@@ -162,12 +162,12 @@ func f_lambertw(z, tol : float = 1e-10):
 			w = wn
 	print("Iteration failed to converge: " + str(z))
 
-func d_lambertw(z : Decimal, tol : float = 1e-10):
+func d_lambertw(z: Decimal, tol: float = 1e-10):
 	var w
 	var ew
 	var wewz
 	var wn
-	
+
 	if not is_finite(z.mag):
 		return z
 	if z.eq(from_components(0, 0, 0)):
@@ -175,7 +175,7 @@ func d_lambertw(z : Decimal, tol : float = 1e-10):
 	if z.eq(from_components(1, 0, 1)):
 		#Split out this case because the asymptotic series blows up
 		return from_number(OMEGA)
-	
+
 	#Get an initial guess for Halley's method
 	w = z.ln()
 	#Halley's method; see 5.9 in [1]
@@ -191,22 +191,22 @@ func d_lambertw(z : Decimal, tol : float = 1e-10):
 
 ### CONSTRUCTORS ###
 
-static func from_decimal(value : Decimal):
+static func from_decimal(value: Decimal):
 	return Decimal.new(value.sign, value.layer, value.mag).normalize()
 
-static func from_components(_sign : int, _layer : int, _mag : float):
+static func from_components(_sign: int, _layer: int, _mag: float):
 	return Decimal.new(_sign, _layer, _mag).normalize()
 
 static func from_number(input):
 	return Decimal.new(sign(input), 0, abs(input)).normalize()
 
-static func from_string(input : String):
+static func from_string(input: String):
 	#TODO
 	pass
 
 ### CONSTRUCTORS (NO NORMALIZE) ###
 
-static func from_components_no_normalize(_sign : int, _layer : int, _mag : float):
+static func from_components_no_normalize(_sign: int, _layer: int, _mag: float):
 	return Decimal.new(_sign, _layer, _mag)
 
 static func from_number_no_normalize(input):
@@ -222,16 +222,16 @@ func normalize():
 		return self
 	#extract sign from negative mag at layer 0
 	if (layer == 0 and mag < 0):
-		mag = -mag
-		sign = -sign
+		mag = - mag
+		sign = - sign
 	#Handle infinities
 	if (mag == INF or layer == INF or mag == -INF or layer == -INF):
 		if (sign == 1):
 			mag = INF;
 			layer = INF;
 		elif (sign == -1):
-			mag = -INF;
-			layer = -INF;
+			mag = - INF;
+			layer = - INF;
 		return self
 	#Handle shifting from layer 0 to negative layers.
 	if (layer == 0 and mag < FIRST_NEG_LAYER):
@@ -256,8 +256,8 @@ func normalize():
 		if (layer == 0):
 			if (mag < 0):
 				#extract sign from negative mag at layer 0
-				mag = -mag
-				sign = -sign
+				mag = - mag
+				sign = - sign
 			elif (mag == 0):
 				#excessive rounding can give us all zeroes
 				sign = 0
@@ -265,7 +265,7 @@ func normalize():
 		sign = NAN
 		layer = NAN
 		mag = NAN
-	
+
 	return self
 
 ### DECONSTRUCTORS ###
@@ -319,28 +319,28 @@ func _to_string():
 			else:
 				return "(e^" + str(layer) + ")" + str(mag)
 
-func to_exponential(places : int):
+func to_exponential(places: int):
 	if layer == 0:
 		#Not sure what to do here, just have it return to_number() for now ~MM
 		#return (sign * mag).to_exponential(places)
 		return to_number()
 	return to_string_with_decimal_places(places)
 
-func to_fixed(places : int):
+func to_fixed(places: int):
 	if layer == 0:
 		#Not sure what to do here either, just have it return snappedi(to_number(), 1) for now ~MM
 		#return (sign * mag).to_fixed(places)
 		return snappedi(to_number(), 1)
 	return to_string_with_decimal_places(places)
 
-func to_precision(places : int):
+func to_precision(places: int):
 	if get_e() <= -7:
 		return to_exponential(places - 1);
 	if places > get_e():
 		return to_fixed(places - get_e() - 1);
 	return to_exponential(places - 1);
 
-func to_string_with_decimal_places(places : int):
+func to_string_with_decimal_places(places: int):
 	if layer == 0:
 		if (mag < 1e21 and mag > 1e-7) or mag == 0:
 			#Still don't know how to convert this here, so just return to_fixed
@@ -364,7 +364,7 @@ func to_string_with_decimal_places(places : int):
 
 ### MAGNITUDE/MANTISSA WITH DECIMAL PLACES ###
 
-func mantissa_with_decimal_places(places : int):
+func mantissa_with_decimal_places(places: int):
 	# https://stackoverflow.com/a/37425022
 	if is_nan(get_m()):
 		return NAN
@@ -372,7 +372,7 @@ func mantissa_with_decimal_places(places : int):
 		return 0
 	return decimal_places(get_m(), places)
 
-func magnitude_with_decimal_places(places : int):
+func magnitude_with_decimal_places(places: int):
 	# https://stackoverflow.com/a/37425022
 	if is_nan(mag):
 		return NAN
@@ -423,25 +423,25 @@ func get_e():
 ### BASIC OPERATIONS ###
 
 #Add
-func add(value : Decimal):
+func add(value: Decimal):
 	if not is_finite(layer):
 		return self
 	if not is_finite(value.layer):
 		return value
-	
+
 	#Special case - if one of the numbers is 0, return the other number.
 	if (sign == 0):
 		return value
 	if (value.sign == 0):
 		return self
-	
+
 	#Special case - Adding a number to its negation produces 0, no matter how large.
 	if (sign == -value.sign) and (layer == value.layer) and (mag == value.mag):
 		return from_components_no_normalize(0, 0, 0)
-	
+
 	var a
 	var b
-	
+
 	#Special case: If one of the numbers is layer 2 or higher, just take the bigger number.
 	if (layer >= 2) or (value.layer >= 2):
 		return maxabs(value)
@@ -451,13 +451,13 @@ func add(value : Decimal):
 	else:
 		a = value
 		b = self
-	
+
 	if (a.layer == 0 && b.layer == 0):
 		return from_number(a.sign * a.mag + b.sign * b.mag)
-	
+
 	var layera = a.layer * sign(a.mag);
 	var layerb = b.layer * sign(b.mag);
-	
+
 	#If one of the numbers is 2+ layers higher than the other, just take the bigger number.
 	if (layera - layerb >= 2):
 		return a
@@ -468,7 +468,7 @@ func add(value : Decimal):
 			var magdiff = pow(10, num_log10(a.mag) - b.mag)
 			var mantissa = b.sign + a.sign * magdiff
 			return from_components(sign(mantissa), 1, b.mag + num_log10(abs(mantissa)))
-	
+
 	if (layera == 1 and layerb == 0):
 		if (abs(a.mag - num_log10(b.mag)) > MAX_SIGNIFICANT_DIGITS):
 			return a
@@ -476,7 +476,7 @@ func add(value : Decimal):
 			var _magdiff = pow(10, a.mag - num_log10(b.mag))
 			var _mantissa = b.sign + a.sign * _magdiff
 			return from_components(sign(_mantissa), 1, num_log10(b.mag) + num_log10(abs(_mantissa)))
-	
+
 	if (abs(a.mag - b.mag) > MAX_SIGNIFICANT_DIGITS):
 		return a
 	else:
@@ -485,29 +485,28 @@ func add(value : Decimal):
 		return from_components(sign(_mantissa2), 1, b.mag + num_log10(abs(_mantissa2)))
 
 #Subtract
-func subtract(value : Decimal):
+func subtract(value: Decimal):
 	return add(value.neg())
 
 #Multiply
-func multiply(value : Decimal):
-	
+func multiply(value: Decimal):
 	#inf/nan check
 	if not is_finite(layer):
 		return self
 	if not is_finite(value.layer):
 		return value
-	
+
 	#Special case - if one of the numbers is 0, return 0.
 	if sign == 0 or value.sign == 0:
 		return from_components_no_normalize(0, 0, 0)
-	
+
 	#Special case - Multiplying a number by its own reciprocal yields +/- 1, no matter how large.
 	if (layer == value.layer) and (mag == -value.mag):
 		return from_components_no_normalize(sign * value.sign, 0, 1)
-	
+
 	var a
 	var b
-	
+
 	#Which number is bigger in terms of its multiplicative distance from 1?
 	if (layer > value.layer) or ((layer == value.layer) and (abs(mag) > abs(value.mag))):
 		a = self
@@ -515,10 +514,10 @@ func multiply(value : Decimal):
 	else:
 		a = value
 		b = self
-	
+
 	if a.layer == 0 and b.layer == 0:
 		return from_number(a.sign * b.sign * a.mag * b.mag)
-	
+
 	#Special case: If one of the numbers is layer 3 or higher or one of the numbers is 2+ layers bigger than the other, just take the bigger number.
 	if a.layer >= 3 or (a.layer - b.layer >= 2):
 		return from_components(a.sign * b.sign, a.layer, a.mag)
@@ -537,14 +536,14 @@ func multiply(value : Decimal):
 		return self
 
 #Divide
-func divide(value : Decimal):
+func divide(value: Decimal):
 	return multiply(value.recip())
 
 #Mod
-func mod(value : Decimal):
+func mod(value: Decimal):
 	if value.eq(from_components(0, 0, 0)):
 		return from_components(0, 0, 0)
-	
+
 	var num_this = self.to_number()
 	var num_decimal = value.to_number()
 	#Special case: To avoid precision issues, if both numbers are valid JS numbers, just call % on those
@@ -558,7 +557,7 @@ func mod(value : Decimal):
 		return self
 	if sign == -1:
 		return _abs().mod(value).neg()
-	
+
 	return subtract(divide(value).floor().multiply(value))
 
 ### NUMBER MODIFICATIONS ###
@@ -581,43 +580,43 @@ func _abs():
 	return from_components_no_normalize(abs(sign), layer, mag)
 
 #Max
-func _max(value : Decimal):
+func _max(value: Decimal):
 	if lt(value):
 		return value
 	else:
 		return self
 
 #Min
-func _min(value : Decimal):
+func _min(value: Decimal):
 	if gt(value):
 		return value
 	else:
 		return self
 
 #Max Abs
-func maxabs(value : Decimal):
+func maxabs(value: Decimal):
 	if cmpabs(value) < 0:
 		return value
 	else:
 		return self
 
 #Min Abs
-func minabs(value : Decimal):
+func minabs(value: Decimal):
 	if cmpabs(value) > 0:
 		return value
 	else:
 		return self
 
 #Clamp
-func _clamp(min : Decimal, max : Decimal):
+func _clamp(min: Decimal, max: Decimal):
 	return _max(min)._min(max)
 
 #Clamp Min
-func clamp_min(min : Decimal):
+func clamp_min(min: Decimal):
 	return _max(min)
 
 #Clamp Max
-func clamp_max(max : Decimal):
+func clamp_max(max: Decimal):
 	return _min(max)
 
 #Round
@@ -647,7 +646,7 @@ func _floor():
 func _ceil():
 	if (mag < 0):
 		if (sign == 1):
-			return from_number(1) #The ceiling function called on something tiny like 10^10^-100 should return 1, since 10^10^-100 is still greater than 0
+			return from_number(1) # The ceiling function called on something tiny like 10^10^-100 should return 1, since 10^10^-100 is still greater than 0
 		else:
 			return from_number(0)
 	if (sign == -1):
@@ -688,7 +687,7 @@ func cube():
 
 #Cubed Root
 func cbrt():
-	return _pow(from_number(1 / 3))
+	return _pow(from_number(1.0 / 3.0))
 
 ### ADVANCED NUMBER MODIFIERS ###
 
@@ -717,7 +716,7 @@ func log10():
 		return from_components(sign, 0, num_log10(mag))
 
 #Log
-func _log(base : Decimal):
+func _log(base: Decimal):
 	if sign <= 0:
 		return from_components(0, 0, NAN)
 	if base.sign <= 0:
@@ -735,9 +734,9 @@ func log2():
 	elif layer == 0:
 		return from_components(sign, 0, num_log2(mag))
 	elif layer == 1:
-		return from_components(sign(mag), 0, abs(mag) * 3.321928094887362) #log2(10)
+		return from_components(sign(mag), 0, abs(mag) * 3.321928094887362) # log2(10)
 	elif layer == 2:
-		return from_components(sign(mag), 1, abs(mag) + 0.5213902276543247) #-log10(log10(2))
+		return from_components(sign(mag), 1, abs(mag) + 0.5213902276543247) # -log10(log10(2))
 	else:
 		return from_components(sign(mag), layer - 1, abs(mag))
 
@@ -748,60 +747,57 @@ func ln():
 	elif layer == 0:
 		return from_components(sign, 0, log(mag))
 	elif layer == 1:
-		return from_components(sign(mag), 0, abs(mag) * 2.302585092994046) #ln(10)
+		return from_components(sign(mag), 0, abs(mag) * 2.302585092994046) # ln(10)
 	elif layer == 2:
-		return from_components(sign(mag), 1, abs(mag) + 0.36221568869946325) #log10(log10(e))
+		return from_components(sign(mag), 1, abs(mag) + 0.36221568869946325) # log10(log10(e))
 	else:
 		return from_components(sign(mag), layer - 1, abs(mag))
 
 #Power
-func _pow(value : Decimal):
-	
+func _pow(value: Decimal):
 	var a = self
 	var b = value
-	
+
 	#special case: if a is 0, then return 0 (UNLESS b is 0, then return 1)
 	if a.sign == 0:
 		if b.eq(from_number(0)):
 			return from_components_no_normalize(1, 0, 1)
 		else:
 			return a
-	
+
 	#special case: if a is 1, then return 1
 	if a.sign == 1 and a.layer == 0 and a.mag == 1:
 		return a
-	
+
 	#special case: if b is 0, then return 1
 	if b.sign == 0:
 		return from_components_no_normalize(1, 0, 1)
-	
+
 	#special case: if b is 1, then return a
 	if b.sign == 1 and b.layer == 0 and b.mag == 1:
 		return a
-	
+
 	var result = a.abs_log10().multiply(b).pow10()
-	
+
 	if sign == -1:
 		if abs(b.to_number() % 2) % 2 == 1:
 			return result.neg()
 		elif abs(b.to_number() % 2) % 2 == 0:
 			return result
 		return from_components(0, 0, NAN)
-	
+
 	return result
 
 #10 to the Power of N
 func pow10():
-	
 	#There are four cases we need to consider:
 	#1) positive sign, positive mag (e15, ee15): +1 layer (e.g. 10^15 becomes e15, 10^e15 becomes ee15)
 	#2) negative sign, positive mag (-e15, -ee15): +1 layer but sign and mag sign are flipped (e.g. 10^-15 becomes e-15, 10^-e15 becomes ee-15)
 	#3) positive sign, negative mag (e-15, ee-15): layer 0 case would have been handled in the Math.pow check, so just return 1
 	#4) negative sign, negative mag (-e-15, -ee-15): layer 0 case would have been handled in the Math.pow check, so just return 1
-	
 	if (not is_finite(layer)) or (not is_finite(mag)):
 		return from_components(0, 0, NAN)
-	
+
 	var a = self
 	#handle layer 0 case - if no precision is lost just use Math.pow, else promote one layer
 	if a.layer == 0:
@@ -813,22 +809,22 @@ func pow10():
 				return from_components(1, 0, 1)
 			else:
 				a = from_components_no_normalize(a.sign, a.layer + 1, num_log10(a.mag))
-	
+
 	#handle all 4 layer 1+ cases individually
 	if a.sign > 0 and a.mag >= 0:
 		return from_components(a.sign, a.layer + 1, a.mag)
 	if a.sign < 0 and a.mag >= 0:
 		return from_components(-a.sign, a.layer + 1, -a.mag)
-	
+
 	#both the negative mag cases are identical: one +/- rounding error
 	return from_components(1, 0, 1)
 
 #Power Base
-func pow_base(value : Decimal):
+func pow_base(value: Decimal):
 	return value.pow(self)
 
 #Root
-func root(value : Decimal):
+func root(value: Decimal):
 	return _pow(value.recip())
 
 #Factorial
@@ -849,9 +845,9 @@ func gamma():
 	elif layer == 0:
 		if lt(from_components_no_normalize(1, 0, 24)):
 			return from_number(f_gamma(sign * mag))
-		
+
 		var t = mag - 1
-		var l = 0.9189385332046727 #0.5*Math.log(2*Math.PI)
+		var l = 0.9189385332046727 # 0.5*Math.log(2*Math.PI)
 		l = l + (t + 0.5) * log(t)
 		l = l - t
 		var n2 = t * t
@@ -901,7 +897,7 @@ func _exp():
 		return from_components(1, layer + 1, sign * mag)
 
 #Layer Add 10
-func layer_add_10(diff : Decimal, linear : bool = false):
+func layer_add_10(diff: Decimal, linear: bool = false):
 	var _diff = diff.to_number()
 	var result = from_decimal(self)
 	if _diff >= 1:
@@ -913,7 +909,7 @@ func layer_add_10(diff : Decimal, linear : bool = false):
 		elif result.sign == -1 and result.layer == 0:
 			#bug fix - for stuff like -3.layeradd10(1) we need to move the sign to the mag
 			result.sign = 1
-			result.mag = -result.mag
+			result.mag = - result.mag
 		var layeradd = snappedi(_diff, 1)
 		diff -= layeradd
 		result.layer += layeradd
@@ -923,7 +919,7 @@ func layer_add_10(diff : Decimal, linear : bool = false):
 		result.layer += _layeradd
 		if result.layer < 0:
 			for i in range(0, 100):
-				++result.layer
+				result.layer += 1
 				result.mag = num_log10(result.mag)
 				if not is_finite(result.mag):
 					#another bugfix: if we hit -Infinity mag, then we should return negative infinity, not 0. 0.layeradd10(-1) h its this
@@ -932,12 +928,12 @@ func layer_add_10(diff : Decimal, linear : bool = false):
 					#also this, for 0.layeradd10(-2)
 					if result.layer < 0:
 						result.layer = 0
-					
+
 					return result.normalize();
 				if result.layer >= 0:
 					break
 	while result.layer < 0:
-		++result.layer
+		result.layer += 1
 		result.mag = num_log10(result.mag)
 	#bugfix: before we normalize: if we started with 0, we now need to manually fix a layer ourselves!
 	if result.sign == 0:
@@ -948,12 +944,12 @@ func layer_add_10(diff : Decimal, linear : bool = false):
 	result.normalize()
 	#layeradd10: like adding 'diff' to the number's slog(base) representation. Very similar to tetrate base 10 and iterated log base 10. Also equivalent to adding a fractional amount to the number's layer in its break_eternity.js representation.
 	if not _diff == 0:
-		return result.layer_add(_diff, 10, linear) #safe, only calls positive height 1 payload tetration, slog and log
+		return result.layer_add(_diff, 10, linear) # safe, only calls positive height 1 payload tetration, slog and log
 
 	return result
 
 #Layer Add
-func layer_add(diff : int, base : int, linear : bool = false):
+func layer_add(diff: int, base: int, linear: bool = false):
 	var slogthis = slog(base).to_number()
 	var slogdest = slogthis + diff
 	if slogdest >= 0:
@@ -968,20 +964,19 @@ func layer_add(diff : int, base : int, linear : bool = false):
 ### ITERATED FUNCTIONS ###
 
 #Tetrate
-func tetrate(height : int = 2, payload : Decimal = from_components_no_normalize(1, 0, 1), linear : bool = false):
-	
+func tetrate(height: int = 2, payload: Decimal = from_components_no_normalize(1, 0, 1), linear: bool = false):
 	#x^^1 == x
 	if height == 1:
 		return _pow(payload)
-	
+
 	#x^^0 == 1
 	if height == 0:
 		return payload
-	
+
 	#1^^x == 1
 	if eq(from_components(1, 0, 1)):
 		return from_components(1, 0, 1)
-	
+
 	#-1^^x == -1
 	if eq(from_number(-1)):
 		return _pow(payload)
@@ -990,15 +985,14 @@ func tetrate(height : int = 2, payload : Decimal = from_components_no_normalize(
 		var this_num = to_number();
 		#within the convergence range?
 		if this_num <= 1.44466786100976613366 and this_num >= 0.06598803584531253708:
-			
 			#hotfix for the very edge of the number range not being handled properly
 			if this_num > 1.444667861009099:
 				return from_number(E)
-			
+
 			#Formula for infinite height power tower.
 			var negln = ln().neg()
 			return negln.lambertw().divide(negln)
-			
+
 		elif this_num > 1.44466786100976613366:
 			#explodes to infinity
 			return from_number(INF)
@@ -1006,7 +1000,7 @@ func tetrate(height : int = 2, payload : Decimal = from_components_no_normalize(
 			#0.06598803584531253708 > this_num >= 0: never converges
 			#this_num < 0: quickly becomes a complex number
 			return from_components(0, 0, NAN)
-		
+
 	#0^^x oscillates if we define 0^0 == 1 (which in javascript land we do), since then 0^^1 is 0, 0^^2 is 1, 0^^3 is 0, etc. payload is ignored
 	#using the linear approximation for height (TODO: don't know a better way to calculate it ATM, but it wouldn't surprise me if it's just NaN)
 	if eq(from_components(0, 0, 0)):
@@ -1014,7 +1008,7 @@ func tetrate(height : int = 2, payload : Decimal = from_components_no_normalize(
 		if result > 1:
 			result = 2 - result
 			return from_number(result)
-		
+
 	if height < 0:
 		return iterated_log(payload.to_number(), -height, linear)
 	var oldheight = height
@@ -1068,11 +1062,11 @@ func tetrate(height : int = 2, payload : Decimal = from_components_no_normalize(
 	return payload
 
 #Iterated Exp
-func iterated_exp(height : int = 2, payload : Decimal = from_components_no_normalize(1, 0 ,1), linear : bool = false):
+func iterated_exp(height: int = 2, payload: Decimal = from_components_no_normalize(1, 0, 1), linear: bool = false):
 	return tetrate(height, payload, linear)
 
 #Iterated Log
-func iterated_log(base : Decimal = from_number(10), times : int = 1, linear : bool = false):
+func iterated_log(base: Decimal = from_number(10), times: int = 1, linear: bool = false):
 	if times < 0:
 		return tetrate(base.to_number(), from_number(-times), linear)
 	var result = from_decimal(self)
@@ -1100,7 +1094,7 @@ func iterated_log(base : Decimal = from_number(10), times : int = 1, linear : bo
 	return result
 
 #Super Log
-func slog(base : int = 10, iterations : int = 100, linear : bool = false):
+func slog(base: int = 10, iterations: int = 100, linear: bool = false):
 	var step_size = 0.001
 	var has_changed_directions_once = false
 	var previously_rose = false
@@ -1126,7 +1120,7 @@ func slog(base : int = 10, iterations : int = 100, linear : bool = false):
 	return from_number(result)
 
 #Super Log (Internal)
-func slog_internal(base : Decimal = from_number(10), linear : bool = false):
+func slog_internal(base: Decimal = from_number(10), linear: bool = false):
 	#special cases:
 	#slog base 0 or lower is NaN
 	if base.lte(from_components(0, 0, 0)):
@@ -1167,7 +1161,7 @@ func slog_internal(base : Decimal = from_number(10), linear : bool = false):
 			copy = copy._log(base)
 	return from_number(result)
 
-#Lambert's W Function 
+#Lambert's W Function
 func lambert_w():
 	if lt(from_number_no_normalize(-0.3678794411710499)):
 		print("lambertw is unimplemented for results less than -1, sorry!")
@@ -1179,10 +1173,10 @@ func lambert_w():
 		return d_lambertw(self)
 	elif layer == 2:
 		return d_lambertw(self)
-	
+
 	if layer >= 3:
 		return from_components_no_normalize(sign, layer - 1, mag)
-	
+
 	print("Unhandled behavior in lambert_w()")
 
 #Super Square Root
@@ -1190,7 +1184,7 @@ func ssqrt():
 	return linear_sroot(2)
 
 #(Linear) Super Root
-func linear_sroot(degree : int):
+func linear_sroot(degree: int):
 	#1st-degree super root just returns its input
 	if degree == 1:
 		return self
@@ -1221,7 +1215,7 @@ func linear_sroot(degree : int):
 	if lt(from_number(0)):
 		return from_components(NAN, NAN, NAN)
 	#Treat all numbers of layer <= -2 as zero, because they effectively are
-	if lte(from_components(1, -2, -16)): #1ee-16
+	if lte(from_components(1, -2, -16)): # 1ee-16
 		if degree % 2 == 1:
 			return self
 		else:
@@ -1237,7 +1231,7 @@ func linear_sroot(degree : int):
 			upperBound = iterated_log(from_number(10), degree - 1, true)
 		if degree <= 1:
 			upperBound = root(from_number(degree))
-		var lower = from_components(0, 0, 0) #This is zero rather than one because we might be on a higher layer, so the lower bound might actually some 10^10^10...^0
+		var lower = from_components(0, 0, 0) # This is zero rather than one because we might be on a higher layer, so the lower bound might actually some 10^10^10...^0
 		var _layer = upperBound.layer
 		var upper = upperBound.iteratedlog(10, _layer, true)
 		var previous = upper
@@ -1274,8 +1268,8 @@ func linear_sroot(degree : int):
 		var stage = 1
 		var minimum = from_components(1, 10, 1)
 		var maximum = from_components(1, 10, 1)
-		var _lower = from_components(1, 10, 1) #eeeeeeeee-10, which is effectively 0; I would use Decimal.dInf but its reciprocal is NaN
-		var _upper = from_components(1, 1, -16) #~ 1 - 1e-16
+		var _lower = from_components(1, 10, 1) # eeeeeeeee-10, which is effectively 0; I would use Decimal.dInf but its reciprocal is NaN
+		var _upper = from_components(1, 1, -16) # ~ 1 - 1e-16
 		var prevspan = from_components(0, 0, 0)
 		var difference = from_components(1, 10, 1)
 		var _upperBound = _upper.pow10().recip()
@@ -1307,7 +1301,7 @@ func linear_sroot(degree : int):
 					prevPoint = _upper.pow10().recip()
 					nextPoint = _upper.pow10().recip()
 					distance = from_components(0, 0, 0)
-					range = -1 #This would cause problems with degree < 1 in the linear approximation... but those are already covered as a special case
+					range = -1 # This would cause problems with degree < 1 in the linear approximation... but those are already covered as a special case
 					if stage == 3:
 						lastValid = _upper
 				elif _upper.pow10().recip().tetrate(degree, from_number(1), true).eq(_upper.pow10().recip()) and (not evenDegree) and _upper.pow10().recip().lt(from_number(0.4)):
@@ -1374,7 +1368,7 @@ func linear_sroot(degree : int):
 					else:
 						var cutOff = false;
 						if infLoopDetector and (range == 1 and stage == 1 or range == -1 and stage == 3):
-							cutOff = true #Avoids infinite loops from floating point imprecision
+							cutOff = true # Avoids infinite loops from floating point imprecision
 						_upper = _upper.add(_lower).divide(from_number(2))
 						if cutOff:
 							break
@@ -1387,7 +1381,7 @@ func linear_sroot(degree : int):
 						#The upper bound is too low, meaning last time we decreased the upper bound, we should have gone to the other half of the new range instead
 						var _cutOff = false;
 						if infLoopDetector and (range == 1 and stage == 1 or range == -1 and stage == 3):
-							_cutOff = true #Avoids infinite loops from floating point imprecision
+							_cutOff = true # Avoids infinite loops from floating point imprecision
 						_lower = _lower.subtract(difference)
 						_upper = _upper.subtract(difference)
 						if _cutOff:
@@ -1398,12 +1392,12 @@ func linear_sroot(degree : int):
 				if _upper.gt(from_number(1e18)):
 					break
 				if (_upper.eq(previousUpper)):
-					break #Another infinite loop catcher
+					break # Another infinite loop catcher
 
 				if _upper.gt(from_number(1e18)):
 					break
 				if not decreasingFound:
-					break #If there's no decreasing range, then even if an error caused lastValid to gain a value, the minimum can't exist
+					break # If there's no decreasing range, then even if an error caused lastValid to gain a value, the minimum can't exist
 				if lastValid == from_components(1, 10, 1):
 					#Whatever we're searching for, it doesn't exist. If there's no minimum, then there's no maximum either, so either way we can end the loop here.
 					break
@@ -1411,7 +1405,7 @@ func linear_sroot(degree : int):
 					minimum = lastValid
 				elif stage == 3:
 					maximum = lastValid
-				++stage
+				stage += 1
 			#Now we have the minimum and maximum, so it's time to calculate the actual super-root.
 			#First, check if the root is in the increasing range.
 			_lower = minimum;
@@ -1472,7 +1466,7 @@ func pentate(height = 2, payload = from_components_no_normalize(1, 0, 1), linear
 	#I have no idea if this is a meaningful approximation for pentation to continuous heights, but it is monotonic and continuous.
 	if not fracheight == 0:
 		if payload.eq(from_number(1)):
-			++height
+			height += 1
 			payload = Decimal.from_number(fracheight);
 		else:
 			if eq(from_number(10)):
@@ -1568,7 +1562,7 @@ func atanh():
 ### COMPARATORS ###
 
 #Compare
-func cmp(value : Decimal):
+func cmp(value: Decimal):
 	if (sign > value.sign):
 		return 1
 	if (sign < value.sign):
@@ -1576,20 +1570,20 @@ func cmp(value : Decimal):
 	return sign * cmpabs(value)
 
 #Compare Abs
-func cmpabs(value : Decimal):
+func cmpabs(value: Decimal):
 	var layera
 	var layerb
-	
+
 	if (mag > 0):
 		layera = layer
 	else:
-		layera = -layer
-	
+		layera = - layer
+
 	if (value.mag > 0):
 		layerb = value.layer
 	else:
-		layerb = -value.layer
-	
+		layerb = - value.layer
+
 	if (layera > layerb):
 		return 1
 	if (layera < layerb):
@@ -1609,40 +1603,40 @@ func _is_finite():
 	return is_finite(sign) and is_finite(layer) and is_finite(mag)
 
 #Equals
-func eq(value : Decimal):
+func eq(value: Decimal):
 	return sign == value.sign and layer == value.layer and mag == value.mag
 
 #Not Equal
-func neq(value : Decimal):
+func neq(value: Decimal):
 	return not eq(value)
 
 #Less Than
-func lt(value : Decimal):
+func lt(value: Decimal):
 	return cmp(value) == -1
 
 #Less Than/Equal To
-func lte(value : Decimal):
+func lte(value: Decimal):
 	return not gt(value)
 
 #Greater Than
-func gt(value : Decimal):
+func gt(value: Decimal):
 	return cmp(value) == 1
 
 #Greater Than/Equal To
-func gte(value : Decimal):
+func gte(value: Decimal):
 	return not lt(value)
 
 ### COMPARATORS (WITH TOLERANCE) ###
 
 #Compare
-func cmp_tolerance(value : Decimal, tolerance : float):
+func cmp_tolerance(value: Decimal, tolerance: float):
 	if eq_tolerance(value, tolerance):
 		return 0
 	else:
 		return cmp(value)
 
 #Equals
-func eq_tolerance(value : Decimal, tolerance : float):
+func eq_tolerance(value: Decimal, tolerance: float):
 	if tolerance == null:
 		tolerance = 1e-7
 	#Numbers that are too far away are never close.
@@ -1657,54 +1651,54 @@ func eq_tolerance(value : Decimal, tolerance : float):
 		magB = f_maglog10(magB)
 	if layer < value.layer:
 		magA = f_maglog10(magA)
-	
+
 	return abs(magA - magB) <= tolerance * max(abs(magA), abs(magB))
 
 #Not Equals
-func neq_tolerance(value : Decimal, tolerance : float):
+func neq_tolerance(value: Decimal, tolerance: float):
 	return not eq_tolerance(value, tolerance)
 
 #Less Than
-func lt_tolerance(value : Decimal, tolerance : float):
+func lt_tolerance(value: Decimal, tolerance: float):
 	return (not eq_tolerance(value, tolerance)) and lt(value)
 
 #Less Than/Equal To
-func lte_tolerance(value : Decimal, tolerance : float):
-	return  eq_tolerance(value, tolerance) or lt(value)
+func lte_tolerance(value: Decimal, tolerance: float):
+	return eq_tolerance(value, tolerance) or lt(value)
 
 #Greater Than
-func gt_tolerance(value : Decimal, tolerance : float):
+func gt_tolerance(value: Decimal, tolerance: float):
 	return (not eq_tolerance(value, tolerance)) and gt(value)
 
 #Greater Than/Equal To
-func gte_tolerance(value : Decimal, tolerance : float):
-	return  eq_tolerance(value, tolerance) or gt(value)
+func gte_tolerance(value: Decimal, tolerance: float):
+	return eq_tolerance(value, tolerance) or gt(value)
 
 ### CORE FUNCTIONS ###
 
-func slog_critical(base : float, height : float):
+func slog_critical(base: float, height: float):
 	#TODO: for bases above 10, revert to old linear approximation until I can think of something better
 	if base > 10:
 		return height - 1
 	return critical_section(base, height, critical_slog_values)
 
-func tetrate_critical(base : float, height : float):
+func tetrate_critical(base: float, height: float):
 	return critical_section(base, height, critical_tetr_values)
 
-func critical_section(base : float, height : float, grid : Array):
+func critical_section(base: float, height: float, grid: Array):
 	#this part is simple at least, since it's just 0.1 to 0.9
 	height *= 10
 	if height < 0:
 		height = 0
 	if height > 10:
 		height = 10
-	
+
 	#have to do this complicated song and dance since one of the critical_headers is E, and in the future I'd like 1.5 as well
 	if base < 2:
 		base = 2
 	if base > 10:
 		base = 10
-	
+
 	var lower = 0
 	var upper = 0
 	#basically, if we're between bases, we interpolate each bases' relevant values together


### PR DESCRIPTION
Attempt to rename all variables matching built-in functions to resolve the numerous warnings in the editor.